### PR TITLE
Fix for other mobile resolutions

### DIFF
--- a/.vuepress/public/style.css
+++ b/.vuepress/public/style.css
@@ -171,7 +171,7 @@ blockquote {
   font-style: italic;
 }
 
-@media only screen and (max-width: 340px) {
+@media only screen and (max-width: 768px) {
   html {
     margin-left: 1rem;
     margin-right: 1rem;


### PR DESCRIPTION
While the previous query works for the smallest size, it cramps up to the corners of the screen on the other sizes, changed to recommended mobile size for readability.

<img src="https://user-images.githubusercontent.com/43572006/129308985-31391184-d15c-4fd3-a7ca-48df8d329f90.jpeg" alt="IMG_730770CE9497-1" width="350">

